### PR TITLE
Fix jumpy layout on devices that support display cutouts

### DIFF
--- a/app/src/main/java/com/example/snapkit/ActivityMainHost.kt
+++ b/app/src/main/java/com/example/snapkit/ActivityMainHost.kt
@@ -1,6 +1,9 @@
 package com.example.snapkit
 
+import android.os.Build
 import android.os.Bundle
+import android.view.View
+import android.view.WindowManager
 import androidx.appcompat.app.AppCompatActivity
 import timber.log.Timber
 
@@ -9,6 +12,7 @@ class ActivityMainHost : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setupTimber()
+        setSystemWindows()
         setContentView(R.layout.activity_main_host)
     }
 
@@ -18,5 +22,21 @@ class ActivityMainHost : AppCompatActivity() {
     private fun setupTimber() {
         Timber.plant(Timber.DebugTree())
         Timber.i("Timber has been planted.")
+    }
+
+    /**
+     * Set initial system window configurations.
+     */
+    private fun setSystemWindows() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            window.attributes.layoutInDisplayCutoutMode =
+                WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
+        }
+
+        window.decorView.systemUiVisibility = (
+                View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                        or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                        or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                )
     }
 }


### PR DESCRIPTION
On devices that contains notches when toggling the system ui in the MediaViewPager the layout will do a brief "jumpy" animation. This is because the layout will resize to be underneath the notch area of the phone, also called the display cutout.